### PR TITLE
Small CSS tweak

### DIFF
--- a/js/style/historydata.css
+++ b/js/style/historydata.css
@@ -1,4 +1,3 @@
-*,:after,:before{box-sizing:border-box;}
 [tabindex="-1"]:focus:not(:focus-visible){outline:0!important;}
 ul{margin-bottom:1rem;}
 ul{margin-top:0;}
@@ -142,7 +141,7 @@ th:focus{outline:none!important;}
 
 .state-queued.dataset{background:#7d959d70;}
 
-*,:after,:before{box-sizing:border-box;}
+.help-button{width: calc(100% - 35px);}
 p{margin-top:0;margin-bottom:1rem;}
 ul{margin-bottom:1rem;}
 ul{margin-top:0;}


### PR DESCRIPTION
The two removed CSS lines were causing a visual bug in all nbtools footers, where the footer would no longer contain the "Run" (or other) buttons. Removing these two lines did change the width of the .help-button element, so one line was added to set it back to its previous width.