### PR TITLE
Register tools in a new thread

### DIFF
--- a/galaxylab/authwidget.py
+++ b/galaxylab/authwidget.py
@@ -147,7 +147,7 @@ class GalaxyAuthWidget(UIBuilder):
         """Get the list available modules (currently only tools) and register widgets for them with the tool manager"""
         url = self.session._notebook_url
 
-        def register_modules_callback
+        def register_modules_callback():
             for section in self.session.tools.gi.tools.get_tool_panel():
                 if section['model_class'] == 'ToolSection':
                     for tool in section['elems']:


### PR DESCRIPTION
Currently it can take a long time to load all the Galaxy tools into the toolbox. This change lets you load those tools in a new thread, so that it doesn't block kernel execution. This way you can continue to work on your notebook while you wait for them to load.